### PR TITLE
[0000012] Into the Fire - Order tug to pick up ECM

### DIFF
--- a/FE_RM_Config/FERemastered/missions/edf07.lua
+++ b/FE_RM_Config/FERemastered/missions/edf07.lua
@@ -827,6 +827,12 @@ function Routine8()
 			AddObjective(_Text1, "white");
 			AudioMessage("e7start.wav");	--Windex:"Corber, you're in charge of escorting the convoy..."
 			SetObjectiveOn(M.Recycler);	--added objective marker on recy for the duration of the escort
+
+			-- Order the tug to pick up the jammer iff both handles exist
+			if IsAround(M.Tug1) and IsAround(M.EcmJammer) then
+				Pickup(M.Tug1, M.EcmJammer, 0);
+			end
+
 			M.Routine8State = M.Routine8State + 1;
 			M.Routine8Timer = GetTime() + 25;	--bumped up from 10 to give the player a bit more time to prepare
 		elseif M.Routine8State == 1 then


### PR DESCRIPTION
When the mission starts order one of the tugs to pick up the ECM pod so
the player doesn't have to.

If this is the wrong spot to put this one let me know an I can change it however you want.

Addresses http://bzccfebugtracker.ddns.net/mantis/view.php?id=12