### PR TITLE
FC01: Removed Debug Spam in Console

### DIFF
--- a/FE_RM_Config/FERemastered/missions/fc01.lua
+++ b/FE_RM_Config/FERemastered/missions/fc01.lua
@@ -323,7 +323,6 @@ function Update()
 	Routine11();
 	Routine14();
 	CheckStuffIsAlive();
-	print(M.Routine1State);
 	for i=1,#M.NewObjs do
 		AddObjectDeferred(M.NewObjs[i]);
 	end


### PR DESCRIPTION
The console was being spammed with prints about the mission state. This has been removed.