### PR TITLE
EDF15 Betrayed - Fixed possible mission stall

### DIFF
--- a/FE_RM_Config/FERemastered/missions/edf15.lua
+++ b/FE_RM_Config/FERemastered/missions/edf15.lua
@@ -182,8 +182,11 @@ function Update()
 	Routine5();
 	Routine7();
 	
-	--keeps Schultz alive during cutscene
-	if M.SchultzInvincible then
+	-- Keep constructor alive.
+	SetCurHealth(M.Constructor, GetMaxHealth(M.Constructor));
+
+	-- Keep Schultz alive.
+	if (M.SchultzInvincible) then
 		SetCurHealth(M.Schultz, GetMaxHealth(M.Schultz));
 	end
 end

--- a/FE_RM_Config/FERemastered/missions/edf15.lua
+++ b/FE_RM_Config/FERemastered/missions/edf15.lua
@@ -24,7 +24,7 @@ local M = {
 	Routine4Active = false,
 	Routine5Active = false,
 	Routine7Active = false,
-	SchultzInvincible = false,
+	SchultzInvincible = true,
 	
 -- Floats
 	Routine1Timer = 0.0,
@@ -184,7 +184,7 @@ function Update()
 	
 	--keeps Schultz alive during cutscene
 	if M.SchultzInvincible then
-		SetCurHealth(M.Constructor, GetMaxHealth(M.Constructor));
+		SetCurHealth(M.Schultz, GetMaxHealth(M.Schultz));
 	end
 end
 
@@ -195,7 +195,6 @@ function Routine1()
 			M.Player = ReplaceObject(M.Player, "ivtank");
 			GiveWeapon(M.Player, "gbchain_c");
 			AudioMessage("edf15a.wav");	--Eisenstein:"The Excluder Jammer seems to be working perfectly..."
-			M.SchultzInvincible = true;--RunSpeed,_Routine9,1,true
 			SetScrap(1, 40);
 			SetScrap(5, 40);
 


### PR DESCRIPTION
If the player destroyed Schultz's tank or the Constructor in the base, the cut-scene would lose reference to either object and cause a stall in the mission. The cut-scene would loop forever.

Addresses: https://github.com/BlackDragonN001/FERemastered/issues/46