### PR TITLE
Crucible tunnel fix

### DIFF
--- a/FE_RM_AssetPacks/CerberiAssetPack/Cerberi/Buildings/cbfact/cbfact.odf
+++ b/FE_RM_AssetPacks/CerberiAssetPack/Cerberi/Buildings/cbfact/cbfact.odf
@@ -46,7 +46,7 @@ detectRange = 100
 tunnelCount = 1
 tunnel01X0 = 2
 tunnel01Z0 = 3
-tunnel01DX = 2
+tunnel01DX = 4
 tunnel01DZ = 4
 tunnel01Edge = "wwtw"
 


### PR DESCRIPTION
Crucible tunnel fix.

Tested by placing one of the Cerberi factories "cbfact.odf" in the editor and building all available units. They now leave the Crucible without issue. 