### PR TITLE
Heavy Chain + Rocket Bomb now consistant

### DIFF
--- a/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF04/EDF04_ODFs/Spartacus ODFs/ibarmo_s.odf
+++ b/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF04/EDF04_ODFs/Spartacus ODFs/ibarmo_s.odf
@@ -13,6 +13,7 @@ buildItem5 = "apbchain"
 [ArmoryGroup2]
 
 [ArmoryGroup3]
+buildItem4 = "apcprktbomb"
 
 [ArmoryGroup4]
 

--- a/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF07/edf07.bzn
+++ b/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF07/edf07.bzn
@@ -3354,7 +3354,7 @@ false
 independence [1] =
 1
 [GameObject]
-objClass = ivrecy
+objClass = ivrecy_s
 seqno [1] =
 442
 team [1] =

--- a/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF14/EDF14_ODFs/ibrecy_e14.odf
+++ b/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF14/EDF14_ODFs/ibrecy_e14.odf
@@ -8,6 +8,6 @@ classLabel = "ibrecy"
 [FactoryClass]
 buildItem2 = "ivspider"
 buildItem4 = "ivsiren"
+buildItem5 = "ivcons_s"
 
 [RecyclerClass]
-


### PR DESCRIPTION
Addresses #33 

The Heavy Rocket and Heavy Chain are now build-able in all missions that use the VENGEANCE (ivrecy_s) Recycler. 