### PR TITLE
Replaced incorrect sound cubes from EDF08 and EDF09

### DIFF
--- a/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF08/edf08.bzn
+++ b/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF08/edf08.bzn
@@ -65595,7 +65595,7 @@ false
 independence [1] =
 
 [GameObject]
-objClass = smbeast3
+objClass = smbeast2
 seqno [1] =
 803637
 team [1] =
@@ -65698,7 +65698,7 @@ false
 independence [1] =
 
 [GameObject]
-objClass = smbeast3
+objClass = smbeast2
 seqno [1] =
 803639
 team [1] =
@@ -65801,7 +65801,7 @@ false
 independence [1] =
 
 [GameObject]
-objClass = smbeast3
+objClass = smbeast2
 seqno [1] =
 80363b
 team [1] =
@@ -67140,7 +67140,7 @@ false
 independence [1] =
 
 [GameObject]
-objClass = smbird1
+objClass = smbeast2
 seqno [1] =
 80368b
 team [1] =

--- a/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF09/edf09.bzn
+++ b/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF09/edf09.bzn
@@ -63405,7 +63405,7 @@ false
 independence [1] =
 1
 [GameObject]
-objClass = smbeast3
+objClass = smbeast2
 seqno [1] =
 803635
 team [1] =
@@ -63508,7 +63508,7 @@ false
 independence [1] =
 1
 [GameObject]
-objClass = smbeast3
+objClass = smbeast1
 seqno [1] =
 803637
 team [1] =
@@ -63611,7 +63611,7 @@ false
 independence [1] =
 1
 [GameObject]
-objClass = smbeast3
+objClass = smbeast2
 seqno [1] =
 803639
 team [1] =
@@ -63714,7 +63714,7 @@ false
 independence [1] =
 1
 [GameObject]
-objClass = smbeast3
+objClass = smbeast2
 seqno [1] =
 80363b
 team [1] =
@@ -65156,7 +65156,7 @@ false
 independence [1] =
 1
 [GameObject]
-objClass = smbird1
+objClass = smbeast2
 seqno [1] =
 80368b
 team [1] =


### PR DESCRIPTION
`smbeast3` was the sound a Jaguar or some other big cat, doesn't make sense for them to be on Miasma so I've switched `smbeast3` ODFs with a mix between `smbeast1` and `smbeast2`.

`smbird1` was a Hawk, which F1 rightly states that there are no birds on Miasma. Replaced with `smbeast1` or `smbeast2`.

Fixes: #77 