### PR TITLE
EDF04 - Fix Hostile Trees

### DIFF
--- a/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF04/edf04.bzn
+++ b/FE_RM_Config/FERemastered/BZ2CP/Campaign/EDF04/edf04.bzn
@@ -30745,7 +30745,7 @@ objClass = fegarg01
 seqno [1] =
 80161a
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000141
@@ -30840,7 +30840,7 @@ objClass = fegarg02
 seqno [1] =
 80161b
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000142
@@ -30935,7 +30935,7 @@ objClass = fegarg02
 seqno [1] =
 80161c
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000143
@@ -31030,7 +31030,7 @@ objClass = fegarg03
 seqno [1] =
 80161e
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000144
@@ -31125,7 +31125,7 @@ objClass = fegarg03
 seqno [1] =
 80161f
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000145
@@ -31220,7 +31220,7 @@ objClass = mopalm02
 seqno [1] =
 801620
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000146
@@ -31315,7 +31315,7 @@ objClass = mopalm02
 seqno [1] =
 801621
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000147
@@ -31410,7 +31410,7 @@ objClass = mopalm02
 seqno [1] =
 801623
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000148
@@ -31505,7 +31505,7 @@ objClass = mopalm02
 seqno [1] =
 801624
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 00000149
@@ -31600,7 +31600,7 @@ objClass = fegarg02
 seqno [1] =
 801625
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 0000014A
@@ -31695,7 +31695,7 @@ objClass = fegarg03
 seqno [1] =
 801626
 team [1] =
-102
+0
 isUser [1] =
 false
 objAddr = 0000014B
@@ -35160,7 +35160,7 @@ objClass = stick
 seqno [1] =
 16e3
 team [1] =
-102
+0
 label = FN
 isUser [1] =
 false


### PR DESCRIPTION
EDF04 - Found a few trees that were placed on the map on Team 6 which caused player units to fire at them. Reset their team to 0 so we don't have issues. 